### PR TITLE
Implement SubstAgent instrumentation for config env substitution

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,3 @@
 [submodule "plugin-suites/Third-Party"]
 	path = plugin-suites/Third-Party
 	url = https://github.com/true-og/Third-Party
-[submodule "SubstAgent"]
-	path = SubstAgent
-	url = https://github.com/true-og/SubstAgent

--- a/SubstAgent/build.gradle
+++ b/SubstAgent/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'java'
+}
+
+group = 'nl.skbotnl'
+version = 'a93eaa3f10'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.javassist:javassist:3.29.2-GA'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
+tasks.jar {
+    archiveBaseName.set('SubstAgent')
+    archiveVersion.set(version)
+    manifest {
+        attributes(
+                'Premain-Class': 'nl.skbotnl.substagent.SubstAgent',
+                'Can-Redefine-Classes': 'true',
+                'Implementation-Version': version
+        )
+    }
+}

--- a/SubstAgent/settings.gradle
+++ b/SubstAgent/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'SubstAgent'

--- a/SubstAgent/src/main/java/nl/skbotnl/substagent/Hook.java
+++ b/SubstAgent/src/main/java/nl/skbotnl/substagent/Hook.java
@@ -1,0 +1,65 @@
+package nl.skbotnl.substagent;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class Hook {
+    private static final Pattern PATTERN = Pattern.compile("\\$([a-zA-Z_][a-zA-Z0-9_]*)");
+
+    private Hook() {
+    }
+
+    public static String substituteEnvVariables(String line) {
+        if (line == null) {
+            return null;
+        }
+
+        return PATTERN.matcher(line).replaceAll(matchResult -> {
+            String env = matchResult.group(1);
+            String envValue = System.getenv(env);
+            if (envValue == null) {
+                return Matcher.quoteReplacement(matchResult.group(0));
+            }
+            return Matcher.quoteReplacement(envValue);
+        });
+    }
+
+    public static char[] substituteEnvVariables(char[] text) {
+        if (text == null) {
+            return null;
+        }
+
+        String textString = String.valueOf(text);
+
+        String replacedString = PATTERN.matcher(textString).replaceAll(matchResult -> {
+            String env = matchResult.group(1);
+            String envValue = System.getenv(env);
+            if (envValue == null) {
+                return Matcher.quoteReplacement(matchResult.group(0));
+            }
+            return Matcher.quoteReplacement(envValue);
+        });
+
+        return replacedString.toCharArray();
+    }
+
+    public static byte[] substituteEnvVariables(byte[] text) {
+        if (text == null) {
+            return null;
+        }
+
+        String textString = new String(text, StandardCharsets.UTF_8);
+
+        String replacedString = PATTERN.matcher(textString).replaceAll(matchResult -> {
+            String env = matchResult.group(1);
+            String envValue = System.getenv(env);
+            if (envValue == null) {
+                return Matcher.quoteReplacement(matchResult.group(0));
+            }
+            return Matcher.quoteReplacement(envValue);
+        });
+
+        return replacedString.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/SubstAgent/src/main/java/nl/skbotnl/substagent/SubstAgent.java
+++ b/SubstAgent/src/main/java/nl/skbotnl/substagent/SubstAgent.java
@@ -1,0 +1,37 @@
+package nl.skbotnl.substagent;
+
+import java.lang.instrument.ClassDefinition;
+import java.lang.instrument.Instrumentation;
+import java.util.Properties;
+
+public final class SubstAgent {
+    private SubstAgent() {
+    }
+
+    public static void premain(String agentArgs, Instrumentation inst) {
+        String version = SubstAgent.class.getPackage() != null
+                ? SubstAgent.class.getPackage().getImplementationVersion()
+                : null;
+        if (version == null || version.isBlank()) {
+            version = "development";
+        }
+        System.out.println("[SubstAgent] Loaded version " + version);
+
+        Transformer transformer = new Transformer();
+        inst.addTransformer(transformer, false);
+
+        if (inst.isRedefineClassesSupported() && inst.isModifiableClass(Properties.class)) {
+            try {
+                ClassDefinition propertiesDefinition = transformer.createPropertiesRedefinition();
+                if (propertiesDefinition != null) {
+                    inst.redefineClasses(propertiesDefinition);
+                    System.out.println("[SubstAgent] Enabled environment variable substitution for java.util.Properties");
+                }
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to redefine java.util.Properties", e);
+            }
+        } else {
+            System.err.println("[SubstAgent] Class redefinition not supported for java.util.Properties; properties files will not substitute environment variables.");
+        }
+    }
+}

--- a/SubstAgent/src/main/java/nl/skbotnl/substagent/Transformer.java
+++ b/SubstAgent/src/main/java/nl/skbotnl/substagent/Transformer.java
@@ -1,0 +1,63 @@
+package nl.skbotnl.substagent;
+
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtMethod;
+import javassist.LoaderClassPath;
+
+import java.lang.instrument.ClassDefinition;
+import java.lang.instrument.ClassFileTransformer;
+import java.security.ProtectionDomain;
+
+class Transformer implements ClassFileTransformer {
+    private static final String HOOK = Hook.class.getName();
+
+    @Override
+    public byte[] transform(
+            ClassLoader loader,
+            String className,
+            Class<?> classBeingRedefined,
+            ProtectionDomain domain,
+            byte[] classfileBuffer) {
+        if (className == null) {
+            return null;
+        }
+
+        try {
+            if ("org/yaml/snakeyaml/nodes/ScalarNode".equals(className)) {
+                return transformScalarNode(loader);
+            }
+        } catch (Throwable e) {
+            throw new IllegalStateException("Failed to transform class " + className, e);
+        }
+
+        return null;
+    }
+
+    ClassDefinition createPropertiesRedefinition() throws Exception {
+        ClassPool cp = ClassPool.getDefault();
+        cp.appendSystemPath();
+        CtClass ctClass = cp.get("java.util.Properties");
+        CtClass objectClass = cp.get("java.lang.Object");
+        CtMethod putMethod = ctClass.getDeclaredMethod("put", new CtClass[]{objectClass, objectClass});
+        putMethod.insertBefore("{ if ($1 instanceof String) { $1 = " + HOOK + ".substituteEnvVariables((String) $1); }" +
+                " if ($2 instanceof String) { $2 = " + HOOK + ".substituteEnvVariables((String) $2); } }");
+        byte[] bytecode = ctClass.toBytecode();
+        ctClass.detach();
+        return new ClassDefinition(Class.forName("java.util.Properties", false, null), bytecode);
+    }
+
+    private byte[] transformScalarNode(ClassLoader loader) throws Exception {
+        ClassPool cp = ClassPool.getDefault();
+        cp.appendSystemPath();
+        if (loader != null) {
+            cp.insertClassPath(new LoaderClassPath(loader));
+        }
+        CtClass ctClass = cp.get("org.yaml.snakeyaml.nodes.ScalarNode");
+        CtMethod getValue = ctClass.getDeclaredMethod("getValue");
+        getValue.insertAfter("{ if ($_ != null) { $_ = " + HOOK + ".substituteEnvVariables($_); } }");
+        byte[] bytecode = ctClass.toBytecode();
+        ctClass.detach();
+        return bytecode;
+    }
+}


### PR DESCRIPTION
## Summary
- replace the SubstAgent submodule with an in-repo Gradle project for building the agent jar
- implement Hook utilities and a SubstAgent premain that redefines java.util.Properties and instruments SnakeYAML scalars to expand environment variables
- configure Gradle packaging so the agent builds with the expected manifest entries

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f8e30da0832faf6eabe33e90a047)